### PR TITLE
修复了输出html格式解析的一个问题

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -77,6 +77,6 @@ def get_exam_links_str():
           <a href="' + links[i].attrs['href'] + '">' + links[i].string + '</a>\
         </li>\
       '
-    exam_links_str += '<ul>'
+    exam_links_str += '</ul>'
   
   return exam_links_str


### PR DESCRIPTION
感谢代码，正好用得上帮妹子筛选信息。使用默认方式输出到html后，火狐浏览器显示的层级关系是错的。修复了一下这个小bug~
原版：
![图片](https://user-images.githubusercontent.com/4684982/77331372-9a83c580-6d5b-11ea-9721-eb52b53296a2.png)
修复后：
![图片](https://user-images.githubusercontent.com/4684982/77331469-ba1aee00-6d5b-11ea-9392-d302ac115bf1.png)
